### PR TITLE
Fix usb dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /.idea
 /node_modules
 /nbproject
+
+# Visual Studio rubbish
+.vs*/
+
+# npm package files
+iobroker.*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,9 @@ node_modules
 test
 .travis.yml
 appveyor.yml
+
+# npm pack files
+iobroker.*.tgz
+
+# Visual Studio rubbish
+.vs*/

--- a/admin/index.html
+++ b/admin/index.html
@@ -28,39 +28,48 @@
 <!-- you have to define 2 functions in the global scope: -->
 <script type="text/javascript">
 
-    var timeout;
+    // remember the onChange handler
+    var _onChange;
 
-    function getComPorts(actualValue) {
-        timeout = setTimeout(function () {
-            getComPorts(actualValue);
-        }, 2000);
-        sendTo(null, 'listUart', null, function (list) {
-            if (timeout) {
-                clearTimeout(timeout);
-                timeout = null;
-            }
-            if (!list || !list.length) {
-                setTimeout(function () {
-                    getComPorts(actualValue);
-                }, 1000);
+
+    function getComPorts() {
+        sendTo(null, 'listSerial', null, function (list) {
+            if (list == null || list.result == null) {
                 return;
             }
-            var text = '<option value="">' + _('Select port') + '</option>';
+            list = list.result;
+
+            var element = $('#serialport');
+            var dropdown = $('<select class="value" id="serialport">')
+                .change(_onChange)
+                .append(
+                    $('<option value="">')
+                        .text(_('Select port'))
+                    )
+                ;
             for (var j = 0; j < list.length; j++) {
                 if (list[j].comName === 'Not available') {
-                    text += '<option value="" selected>' + _('Not available') + '</option>';
-                    $('#usb').prop('disabled', true);
+                    dropdown.append(
+                        $('<option value="" selected>').text(_('Not available'))
+                    );
+                    dropdown.attr('disabled', 'disabled');
                     break;
                 } else {
-                    text += '<option value="' + list[j].comName + '" ' + ((actualValue === list[j].comName) ? 'selected' : '') + '>' + list[j].comName + '</option>';
+                    dropdown.append(
+                        $('<option ' + ((element.val() === list[j].comName) ? 'selected' : '') + '>')
+                            .attr('value', list[j].comName)
+                            .text(list[j].comName)
+                    );
                 }
             }
-            $('#usb').html(text);
+            element.replaceWith(dropdown);
         });
     }
 
     // the function loadSettings has to exist ...
     function load(settings, onChange) {
+        // remember the onChange handler
+        _onChange = onChange;
         // example: select elements with id=key and class=value and insert value
         if (!settings) return;
         $('.value').each(function () {
@@ -78,6 +87,10 @@
                 });
             }
         });
+
+        // Populate the dropdown for USB/COM ports instead of
+        getComPorts();
+
         onChange(false);
     }
 
@@ -88,11 +101,11 @@
         var obj = {};
         $('.value').each(function () {
             var $this = $(this);
-			if ($this.attr('type') === 'checkbox') {
-				obj[$this.attr('id')] = $this.prop('checked');
-			} else {
-				obj[$this.attr('id')] = $this.val();
-			}
+            if ($this.attr('type') === 'checkbox') {
+                obj[$this.attr('id')] = $this.prop('checked');
+            } else {
+                obj[$this.attr('id')] = $this.val();
+            }
         });
         callback(obj);
     }
@@ -112,16 +125,11 @@
         </tr>
         <tr>
             <td><label for="timeout" class="translate">Timeout</label></td>
-            <td><input class="value" id="timeout" type="input"/></td>
+            <td><input class="value" id="timeout" type="text"/></td>
         </tr>
         <tr>
-            <td><label  class="translate" for="usb">USB name:</label></td>
-            <td class="admin-icon"></td>
-            <td id="_usb"><select class="value" id="usb"></select></td>
-        </tr>
-        <tr>
-            <td><label for="serialport" class="translate">Serialport</label></td>
-            <td><input class="value" id="serialport" type="input"/></td>
+            <td><label for="serialport" class="translate">Serial port:</label></td>
+            <td><input class="value" id="serialport" type="text" /></td>
         </tr>
     </table>
     <p class="translate">on save adapter restarts with new config immediately</p>

--- a/admin/words.js
+++ b/admin/words.js
@@ -1,12 +1,14 @@
 // Dictionary (systemDictionary is global variable from adapter-settings.js)
 systemDictionary = {
-	"EnOcean adapter settings":   {"de": "EnOcean", "ru": "EnOcean"},
+    "EnOcean adapter settings":   {"de": "EnOcean", "ru": "EnOcean"},
     "teachIn":                    {"en": "Teach mode", "de": "Anlernmodus", "ru": "режим обучения"},
     "Timeout":                    {"en": "Timeout", "de": "Timeout", "ru": "Тайм-аут"},
-    "USB name:":                 {"en": "USB name:", "de": "USB Name:", "ru": "Имя USB"},
-    "Serialport":                 {"en": "Serialport:", "de": "Serialport", "ru": "Имя USB"},
-	"on save adapter restarts with new config immediately": {
-		"de": "Beim Speichern von Einstellungen der Adapter wird sofort neu gestartet.",
-		"ru": "При сохранении настроек адаптера он сразу же перезапускается"
-	}
+    "Serial port:":               {"de": "Schnittstelle:", "ru": "Имя USB"},
+    "Select port":				  {"de": "Port auswählen", "ru": "выбрать порт" },
+    "Not available":			  {"de": "Nicht verfügbar" },
+
+    "on save adapter restarts with new config immediately": {
+        "de": "Beim Speichern von Einstellungen der Adapter wird sofort neu gestartet.",
+        "ru": "При сохранении настроек адаптера он сразу же перезапускается"
+    }
 };

--- a/io-package.json
+++ b/io-package.json
@@ -43,7 +43,6 @@
     "native": {
         "teachMode": false,
         "timeout": 60,
-        "usb": "",
         "serialport": "/dev/ttyUSB0"
     },
     "objects": [


### PR DESCRIPTION
Das sollte die USB-Auswahl im Admin ermöglichen. Funktioniert aber erst so halb, da bei Auswahl eines falschen Ports der Adapter abstürzt. Da ist noch ein bisschen was von deiner Seite aus zu tun.

Hab außerdem mein Framework für den on-message-Handler hinzugefügt, der in zwave und meinen anderen Adaptern steckt. So lassen sich neue sendTo-Kommandos einfach hinzufügen.