### PR TITLE
"Geräte vergessen" wieder aktiviert

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -148,6 +148,19 @@
                 ack: false
             });
         });
+        $("#removeDevice").click(function () {
+            // activate forget mode on click on the button
+            socket.emit("setState", namespace + ".info.learnMode", {
+                val: 2, /* forget */
+                ack: false
+            });
+        });
+        // check for current state of the learn mode
+        socket.emit("getState", namespace + ".info.learnMode", function (err, state) {
+            if (err == null && state != null) {
+                updateLearnMode(state.val);
+            }
+        })
 
         // Signal to admin, that no changes yet
         onChange(false);
@@ -174,24 +187,39 @@
         // only watch our own states
         if (id.substring(0, namespaceLen) !== namespace) return;
 
-        if (id.match(/\.info\.learnMode$/)) {
-            // learn mode was updated
-            var container = $("#manageDevices");
-            var learnButton = $("#addDevice");
-            switch (state.val) {
-                case 0: // idle
-                    // enable the button and hide the message
-                    container.toggleClass("active", false);
-                    learnButton.attr("disabled", null);
-                    break;
-                case 1: // learning
-                    // disable the button and show the message
-                    container.toggleClass("active", true);
-                    learnButton.attr("disabled", "disabled");
-                    break;
+        if (state != null) {
+            if (id.match(/\.info\.learnMode$/)) {
+                updateLearnMode(state.val);
             }
         }
     });
+
+    function updateLearnMode(value) {
+        // learn mode was updated
+        var container = $("#manageDevices");
+        var learnButton = $("#addDevice");
+        var forgetButton = $("#removeDevice");
+        switch (value) {
+            case 0: // idle
+                // enable the buttons and hide the message
+                container.toggleClass("active", false);
+                learnButton.attr("disabled", null);
+                forgetButton.attr("disabled", null);
+                break;
+            case 1: // learning
+                // disable the button and show the message
+                container.toggleClass("active", true);
+                learnButton.attr("disabled", "disabled");
+                forgetButton.attr("disabled", null);
+                break;
+            case 2: // forgetting
+                // disable the button and show the message
+                container.toggleClass("active", true);
+                learnButton.attr("disabled", null);
+                forgetButton.attr("disabled", "disabled");
+                break;
+        }
+    }
 
 </script>
 
@@ -212,6 +240,7 @@
     <h4 class="translate">Manage devices</h4>
     <p id="manageDevices">
         <button class="translate" id="addDevice">add device</button>
+        <button class="translate" id="removeDevice">remove device</button>
         <span class="translate active">please wait...</span>
     </p>
 

--- a/admin/words.js
+++ b/admin/words.js
@@ -1,11 +1,26 @@
 // Dictionary (systemDictionary is global variable from adapter-settings.js)
 systemDictionary = {
-    "EnOcean adapter settings":   {"de": "EnOcean", "ru": "EnOcean"},
-    "teachIn":                    {"en": "Teach mode", "de": "Anlernmodus", "ru": "режим обучения"},
-    "Timeout":                    {"en": "Timeout", "de": "Timeout", "ru": "Тайм-аут"},
-    "Serial port:":               {"de": "Schnittstelle:", "ru": "Имя USB"},
-    "Select port":				  {"de": "Port auswählen", "ru": "выбрать порт" },
-    "Not available":			  {"de": "Nicht verfügbar" },
+    "EnOcean adapter settings": { 
+        "de": "EnOcean", "ru": "EnOcean" 
+    },
+    "Timeout": { 
+        "en": "Timeout", "de": "Timeout", "ru": "Тайм-аут" 
+    },
+    "Serial port:": { 
+        "de": "Schnittstelle:", "ru": "Имя USB" 
+    },
+    "Select port": { 
+        "de": "Port auswählen", "ru": "выбрать порт" 
+    },
+    "Not available": { 
+        "de": "Nicht verfügbar" 
+    },
+    "add device": { 
+        "de": "Gerät hinzufügen" 
+    },
+    "remove device": { 
+        "de": "Gerät entfernen" 
+    },
 
     "on save adapter restarts with new config immediately": {
         "de": "Beim Speichern von Einstellungen der Adapter wird sofort neu gestartet.",

--- a/main.js
+++ b/main.js
@@ -115,9 +115,7 @@ adapter.on('stateChange', (id, state) => {
             if (learnMode !== "learning" && state.val === 1 /* learning */) {
                 startLearning();
             } else if (learnMode !== "forgetting" && state.val === 2 /* forgetting */) {
-                adapter.log.warn("Forgetting devices is currently not supported due to a bug in the node-enocean package!");
-                adapter.setState(id, 0, true); // fall back to idle
-                //startForgetting();
+                startForgetting();
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/jey-cee/ioBroker.enocean"
   },
   "dependencies": {
-    "node-enocean": "3.1.1"
+    "node-enocean": "^3.2.1"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Der Bug, der zur Korruption der Sensor-DB geführt hat, wurde in node-enocean@3.2.1 behoben:
https://github.com/node-enocean/node-enocean/issues/33
D.h. wir können den Vergessen-Modus zur Verfügung stellen.