### PR TITLE
Add support for non-standard devices

### DIFF
--- a/eep/EEP2IOB.json
+++ b/eep/EEP2IOB.json
@@ -90,5 +90,14 @@
         ]
       }
     }
+  },
+  "unknown": {
+    "desc": {
+      "native": {
+        "iobObjects": [
+          {"id": "raw","common.name": "raw telegram","common.type": "string", "common.role": "value", "common.read": "true", "common.write": "false"}
+        ]
+      }
+    }
   }
 }

--- a/eep/eepInclude.js
+++ b/eep/eepInclude.js
@@ -7,7 +7,7 @@ var eepTable = {
     f6_02_03_native: require('./f6-02-03.js'),
     f6_02_01_smokedetector_1: require('./SmokeDetector-1.js'),
     f6_10_00_native: require('./f6-10-00.js'),
-    unknown_native: require('./unknown'),
+    unknown_native: require('./unknown.js'),
 };
 
 module.exports = eepTable;

--- a/eep/eepInclude.js
+++ b/eep/eepInclude.js
@@ -1,12 +1,13 @@
 
 var eepTable = {
-    a5_02_05_native : require('./a5-02-05.js'),
-    d5_00_01_native : require('./d5-00-01.js'),
-    f6_02_01_native : require('./f6-02-01.js'),
-    f6_02_02_native : require('./f6-02-02.js'),
-    f6_02_03_native : require('./f6-02-03.js'),
-    f6_02_01_smokedetector_1 : require('./SmokeDetector-1.js'),
-    f6_10_00_native : require('./f6-10-00.js')
+    a5_02_05_native: require('./a5-02-05.js'),
+    d5_00_01_native: require('./d5-00-01.js'),
+    f6_02_01_native: require('./f6-02-01.js'),
+    f6_02_02_native: require('./f6-02-02.js'),
+    f6_02_03_native: require('./f6-02-03.js'),
+    f6_02_01_smokedetector_1: require('./SmokeDetector-1.js'),
+    f6_10_00_native: require('./f6-10-00.js'),
+    unknown_native: require('./unknown'),
 };
 
-module.exports=eepTable;
+module.exports = eepTable;

--- a/eep/unknown.js
+++ b/eep/unknown.js
@@ -1,0 +1,15 @@
+"use strict";
+
+// required for autocompletion
+const RadioTelegram = require('../lib/esp3Packet').RadioTelegram;
+
+/**
+ * DEFAULT parser for unknown packets
+ */
+
+/**
+ * @param {RadioTelegram} telegram 
+ */
+module.exports = function (telegram) {
+    return { raw: telegram.userData.toString("hex") };
+}


### PR DESCRIPTION
My multisensor is using non-standard telegrams as it is a development version and not certified yet. To support such devices, I added the EEP `"unknown"` with a very basic "parser". That way, non-standard devices or devices with an EEP not supported by the adapter can be used and parsed via custom scripts:
![raw](https://user-images.githubusercontent.com/17641229/35585144-64f4d6d4-05f7-11e8-9f32-39ee8818e5b2.PNG)

Here's an example of parsing via an external script:
![raw2](https://user-images.githubusercontent.com/17641229/35585158-7309b924-05f7-11e8-9ac0-6894a6a1e1ee.PNG)
